### PR TITLE
fix(gradle): downgrade to version 2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,11 +2,10 @@
 buildscript {
     repositories {
         jcenter()
-        google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:2.2.3'
     }
 }
 
@@ -33,9 +32,8 @@ android {
 
 repositories {
     mavenCentral()
-    google()
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
+    compile 'com.facebook.react:react-native:+'
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
### Proposal:
Downgrade to use gradle 2.

### Motivation:
react-native init and most native packages use uses gradle 2 and trying to build this package with gradle 2 throws an error described on this issue: https://github.com/entria/react-native-view-overflow/issues/2.

