### PR TITLE
pod homepage fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ import ViewOverflow from 'react-native-view-overflow';
 
 #### iOS
 
+via CocoaPods:
+
+1. Open comand line in your project IOS folder, and run command `pod install`.
+2. Run your project (`Cmd+R`)
+
+or via Libraries:
+
 1. In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
 2. Go to `node_modules` ➜ `react-native-view-overflow` and add `RNViewOverflow.xcodeproj`
 3. In XCode, in the project navigator, select your project. Add `libRNViewOverflow.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`

--- a/ios/RNViewOverflow.podspec
+++ b/ios/RNViewOverflow.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNViewOverflow
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/entria/react-native-view-overflow"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
1. Fix to CocoaPods empty 'homepage' error
2. Add instructions for installation via CocoaPods