### PR TITLE
remove unnecessary windows dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "license": "MIT",
   "main": "src/index.js",
   "peerDependencies": {
-    "react-native": ">=0.41.2",
-    "react-native-windows": ">=0.41.0-rc.1"
+    "react-native": ">=0.41.2"
   },
   "scripts": {
     "release:major": "npm version major && git push origin && git push origin --follow-tags",


### PR DESCRIPTION
It doesn't use `react-native-windows` in any meaningful way - we don't need this as a warning/error cluttering our builds