### PR TITLE
Added homepage to package.json for rn ^0.59

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "solve view overflow in android",
   "version": "0.0.4",
   "author": "entria",
+  "homepage": "https://github.com/entria/react-native-view-overflow",
   "keywords": [
     "react-native"
   ],


### PR DESCRIPTION
Sets the homepage so users of RN ^0.59 can use cocoa pods without manually editing the generated Podfile.