### PR TITLE
Updated readme, removed link step for react-native>0.60.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,14 @@ This could make code simpler, so you don't need to move some Components outside 
 You can read more about the motivation and this package here https://medium.com/@sibelius/solving-view-overflow-in-android-reactnative-f961752a75cd
 
 ## Getting started
+### Steps to (mostly) automatically install react-native-view-overflow
+#### If you are using react-native >=.60
 
 `$ npm install react-native-view-overflow --save`
 
-### Mostly automatic installation
+#### Otherwise, if you are using react-native <.60 
+
+`$ npm install react-native-view-overflow --save`
 
 `$ react-native link react-native-view-overflow`
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ You can read more about the motivation and this package here https://medium.com/
 
 ## Getting started
 ### Steps to (mostly) automatically install react-native-view-overflow
-#### If you are using react-native >=.60
+#### If you are using react-native >=0.60.0
 
 `$ npm install react-native-view-overflow --save`
 
-#### Otherwise, if you are using react-native <.60 
+#### Otherwise, if you are using react-native <0.60.0 
 
 `$ npm install react-native-view-overflow --save`
 


### PR DESCRIPTION
As of react-native cli .6, autolinking has removed the need to manually link native dependencies.
https://github.com/react-native-community/cli/blob/master/docs/autolinking.md

I've updated the readme to specify the modified getting started steps for react-native>.6