### PR TITLE
Fix missing repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   "peerDependencies": {
     "react-native": ">=0.41.2"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/entria/react-native-view-overflow.git"
+  },
   "scripts": {
     "release:major": "npm version major && git push origin && git push origin --follow-tags",
     "release:minor": "npm version minor && git push origin && git push origin --follow-tags",


### PR DESCRIPTION
This is not a bug and very minor thing. But our react native app use your package as an dependency. We list your app in `Open source licenses` section. However due to missing `repository` attribute in package.json, anytime users click the link it will crash the app. There are many way to fix this, but I think it's still better to make a PR for adding this.

The current license that get form `npm-license-crawler`
```
   "react-native-view-overflow": {
        "licenses": "MIT",
        "parents": "hsl-app"
    },
``